### PR TITLE
fix: add cursor pointer to unstyled button

### DIFF
--- a/src/components/atoms/Button/Button.module.css
+++ b/src/components/atoms/Button/Button.module.css
@@ -24,6 +24,7 @@
     font-size: inherit;
     font-weight: inherit;
     color: inherit;
+    cursor: pointer;
 }
 
 @media screen and (max-width: 800px) {


### PR DESCRIPTION
Hey 👋🏼 
Noticed missing `cursor: pointer` on buttons while looking at the website.
Let me know what you think :)

Before:
<img width="502" alt="before-pointer" src="https://github.com/user-attachments/assets/973cbf8e-f385-403b-af1e-39a86a2d805f">

After:
<img width="442" alt="after-pointer" src="https://github.com/user-attachments/assets/ff9939a2-e80b-4a57-9b78-2593a6ea0d36">
